### PR TITLE
Add the option to enable the mono soft debugger

### DIFF
--- a/Proxy/config.c
+++ b/Proxy/config.c
@@ -41,6 +41,7 @@ inline void init_config_file() {
     load_path_file(config_path, L"MonoBackend", L"runtimeLib", NULL, &config.mono_lib_dir);
     load_path_file(config_path, L"MonoBackend", L"configDir", NULL, &config.mono_config_dir);
     load_path_file(config_path, L"MonoBackend", L"corlibDir", NULL, &config.mono_corlib_dir);
+    load_bool_file(config_path, L"MonoBackend", L"debug", L"false", &config.mono_debug);
 
     free(config_path);
 }
@@ -89,6 +90,7 @@ inline void init_cmd_args() {
         PARSE_ARG(L"--mono-runtime-lib", config.mono_lib_dir, load_path_argv);
         PARSE_ARG(L"--mono-config-dir", config.mono_config_dir, load_path_argv);
         PARSE_ARG(L"--mono-corlib-dir", config.mono_config_dir, load_path_argv);
+        PARSE_ARG(L"--mono-debug", config.mono_debug, load_bool_argv);
     }
 
     LocalFree(argv);

--- a/Proxy/config.h
+++ b/Proxy/config.h
@@ -15,6 +15,7 @@ struct {
     wchar_t *mono_config_dir;
     wchar_t *mono_corlib_dir;
     wchar_t *mono_dll_search_path_override;
+    BOOL mono_debug;
 } config;
 
 

--- a/Proxy/main.c
+++ b/Proxy/main.c
@@ -203,7 +203,20 @@ int init_doorstop_il2cpp(const char *domain_name) {
     mono_set_assemblies_path(mono_corlib_dir_narrow);
     mono_config_parse(NULL);
 
+    if (config.mono_debug) {
+        const char* opt[] = {
+            "--debugger-agent=transport=dt_socket,server=y,address=127.0.0.1:55555",
+            "--soft-breakpoints"
+        };
+        mono_jit_parse_options(2, opt);
+        mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+    }
+
     void *domain = mono_jit_init_version("Doorstop Root Domain", NULL);
+    if (config.mono_debug) {
+        mono_debug_domain_create(domain);
+        LOG("Mono debugging enabled\n");
+    }
     LOG("Created domain: %p\n", domain);
 
     doorstop_invoke(domain);

--- a/Proxy/mono.h
+++ b/Proxy/mono.h
@@ -53,6 +53,18 @@ void *(*mono_image_open_from_data_with_name)(void *data, DWORD data_len, int nee
 void* (*mono_get_exception_class)();
 void* (*mono_object_get_virtual_method)(void* obj_raw, void* method);
 
+void* (*mono_jit_parse_options)(int argc, const char* argv);
+
+typedef enum {
+    MONO_DEBUG_FORMAT_NONE,
+    MONO_DEBUG_FORMAT_MONO,
+    /* Deprecated, the mdb debugger is not longer supported. */
+    MONO_DEBUG_FORMAT_DEBUGGER
+} MonoDebugFormat;
+
+void* (*mono_debug_init)(MonoDebugFormat format);
+void* (*mono_debug_domain_create)(void* domain);
+
 /**
 * \brief Loads Mono C API function pointers so that the above definitions can be called.
 * \param mono_lib Mono.dll module.
@@ -87,6 +99,9 @@ inline void load_mono_functions(HMODULE mono_lib) {
     GET_MONO_PROC(mono_image_open_from_data_with_name);
     GET_MONO_PROC(mono_get_exception_class);
     GET_MONO_PROC(mono_object_get_virtual_method);
+    GET_MONO_PROC(mono_jit_parse_options);
+    GET_MONO_PROC(mono_debug_init);
+    GET_MONO_PROC(mono_debug_domain_create);
 
 #undef GET_MONO_PROC
 }

--- a/docs/dist_readme.md
+++ b/docs/dist_readme.md
@@ -115,6 +115,8 @@ runtimeLib=
 configDir=
 # Path to core managed assemblies (mscorlib et al.) directory
 corlibDir=
+# Specifies whether the mono soft debugger is enabled (listening on port 55555)
+debug=false
 ```
 
 ## Configuration via command-line arguments

--- a/docs/doorstop_config.ini
+++ b/docs/doorstop_config.ini
@@ -27,3 +27,5 @@ runtimeLib=
 configDir=
 # Path to core managed assemblies (mscorlib et al.) directory
 corlibDir=
+# Specifies whether the mono soft debugger is enabled (listening on port 55555)
+debug=false


### PR DESCRIPTION
The original patch is made by 6pak.
I added a simple config option.

If you enable the debug option, the embedded mono runtime enables the soft debugger that listens on localhost port 55555.