### PR TITLE
Add the option to enable the mono soft debugger 

### DIFF
--- a/Proxy/config.h
+++ b/Proxy/config.h
@@ -15,6 +15,8 @@ struct {
     wchar_t *mono_config_dir;
     wchar_t *mono_corlib_dir;
     wchar_t *mono_dll_search_path_override;
+    BOOL mono_debug_enabled;
+    wchar_t* mono_debug_address;
 } config;
 
 

--- a/Proxy/main.c
+++ b/Proxy/main.c
@@ -203,7 +203,18 @@ int init_doorstop_il2cpp(const char *domain_name) {
     mono_set_assemblies_path(mono_corlib_dir_narrow);
     mono_config_parse(NULL);
 
+    const char* opt[2] =
+    {
+        "--debugger-agent=address=0.0.0.0:10000,transport=dt_socket,server=y",
+        "--soft-breakpoints"
+    };
+
+    mono_jit_parse_options(2, opt);
+
+    mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+
     void *domain = mono_jit_init_version("Doorstop Root Domain", NULL);
+    mono_debug_domain_create(domain);
     LOG("Created domain: %p\n", domain);
 
     doorstop_invoke(domain);

--- a/Proxy/main.c
+++ b/Proxy/main.c
@@ -203,18 +203,34 @@ int init_doorstop_il2cpp(const char *domain_name) {
     mono_set_assemblies_path(mono_corlib_dir_narrow);
     mono_config_parse(NULL);
 
-    const char* opt[2] =
-    {
-        "--debugger-agent=address=0.0.0.0:10000,transport=dt_socket,server=y",
-        "--soft-breakpoints"
-    };
+    if (config.mono_debug_enabled) {
+        const char* debugger_option = "--debugger-agent=transport=dt_socket,server=y,address=";
+        size_t len_debugger_option = strlen(debugger_option);
+        char* debug_address = narrow(config.mono_debug_address);
+        size_t len_debug_address = strlen(debug_address);
 
-    mono_jit_parse_options(2, opt);
+        size_t len_option = len_debugger_option + len_debug_address;
+        char* option = malloc((len_option + 1) * sizeof(char));
+        memcpy(option, debugger_option, len_debugger_option);
+        memcpy(option + len_debugger_option, debug_address, len_debug_address);
+        option[len_option + 1] = '\0';
 
-    mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+        const char* options[] = {
+            option,
+            "--soft-breakpoints"
+        };
+        mono_jit_parse_options(2, options);
+        mono_debug_init(MONO_DEBUG_FORMAT_MONO);
+        LOG("Mono debugger listening on %s\n", debug_address);
+
+        free(option);
+        free(debug_address);
+    }
 
     void *domain = mono_jit_init_version("Doorstop Root Domain", NULL);
-    mono_debug_domain_create(domain);
+    if (config.mono_debug_enabled) {
+        mono_debug_domain_create(domain);
+    }
     LOG("Created domain: %p\n", domain);
 
     doorstop_invoke(domain);

--- a/Proxy/mono.h
+++ b/Proxy/mono.h
@@ -53,6 +53,18 @@ void *(*mono_image_open_from_data_with_name)(void *data, DWORD data_len, int nee
 void* (*mono_get_exception_class)();
 void* (*mono_object_get_virtual_method)(void* obj_raw, void* method);
 
+void* (*mono_jit_parse_options)(int argc, const char *argv);
+
+typedef enum {
+    MONO_DEBUG_FORMAT_NONE,
+    MONO_DEBUG_FORMAT_MONO,
+    /* Deprecated, the mdb debugger is not longer supported. */
+    MONO_DEBUG_FORMAT_DEBUGGER
+} MonoDebugFormat;
+
+void* (*mono_debug_init)(MonoDebugFormat format);
+void* (*mono_debug_domain_create)(void *domain);
+
 /**
 * \brief Loads Mono C API function pointers so that the above definitions can be called.
 * \param mono_lib Mono.dll module.
@@ -87,6 +99,9 @@ inline void load_mono_functions(HMODULE mono_lib) {
     GET_MONO_PROC(mono_image_open_from_data_with_name);
     GET_MONO_PROC(mono_get_exception_class);
     GET_MONO_PROC(mono_object_get_virtual_method);
+    GET_MONO_PROC(mono_jit_parse_options);
+    GET_MONO_PROC(mono_debug_init);
+    GET_MONO_PROC(mono_debug_domain_create);
 
 #undef GET_MONO_PROC
 }

--- a/Proxy/mono.h
+++ b/Proxy/mono.h
@@ -53,7 +53,7 @@ void *(*mono_image_open_from_data_with_name)(void *data, DWORD data_len, int nee
 void* (*mono_get_exception_class)();
 void* (*mono_object_get_virtual_method)(void* obj_raw, void* method);
 
-void* (*mono_jit_parse_options)(int argc, const char *argv);
+void* (*mono_jit_parse_options)(int argc, const char* argv);
 
 typedef enum {
     MONO_DEBUG_FORMAT_NONE,
@@ -63,7 +63,7 @@ typedef enum {
 } MonoDebugFormat;
 
 void* (*mono_debug_init)(MonoDebugFormat format);
-void* (*mono_debug_domain_create)(void *domain);
+void* (*mono_debug_domain_create)(void* domain);
 
 /**
 * \brief Loads Mono C API function pointers so that the above definitions can be called.

--- a/docs/dist_readme.md
+++ b/docs/dist_readme.md
@@ -115,6 +115,10 @@ runtimeLib=
 configDir=
 # Path to core managed assemblies (mscorlib et al.) directory
 corlibDir=
+# Specifies whether the mono soft debugger is enabled
+debugEnabled=false
+# Specifies the listening address the soft debugger
+debugAddress=127.0.0.1:10000
 ```
 
 ## Configuration via command-line arguments

--- a/docs/doorstop_config.ini
+++ b/docs/doorstop_config.ini
@@ -27,3 +27,7 @@ runtimeLib=
 configDir=
 # Path to core managed assemblies (mscorlib et al.) directory
 corlibDir=
+# Specifies whether the mono soft debugger is enabled
+debugEnabled=false
+# Specifies the listening address the soft debugger
+debugAddress=127.0.0.1:10000


### PR DESCRIPTION
Based on the patch of 6pak.
Added two options.
The first option enables the mono soft debugger. (default false)
The second option the tcp address of the debugger. (default 127.0.0.1:10000)