### PR TITLE
Add the option to suspend the process for the debugger

### DIFF
--- a/Proxy/config.c
+++ b/Proxy/config.c
@@ -48,6 +48,7 @@ inline void init_config_file() {
     load_path_file(config_path, L"MonoBackend", L"configDir", NULL, &config.mono_config_dir);
     load_path_file(config_path, L"MonoBackend", L"corlibDir", NULL, &config.mono_corlib_dir);
     load_bool_file(config_path, L"MonoBackend", L"debugEnabled", L"false", &config.mono_debug_enabled);
+    load_bool_file(config_path, L"MonoBackend", L"debugSuspend", L"false", &config.mono_debug_suspend);
     load_string_file(config_path, L"MonoBackend", L"debugAddress", L"127.0.0.1:10000", &config.mono_debug_address);
 
     free(config_path);
@@ -111,6 +112,7 @@ inline void init_cmd_args() {
         PARSE_ARG(L"--mono-config-dir", config.mono_config_dir, load_path_argv);
         PARSE_ARG(L"--mono-corlib-dir", config.mono_config_dir, load_path_argv);
         PARSE_ARG(L"--mono-debug-enabled", config.mono_debug_enabled, load_bool_argv);
+        PARSE_ARG(L"--mono-debug-suspend", config.mono_debug_suspend, load_bool_argv);
         PARSE_ARG(L"--mono-debug-address", config.mono_debug_address, load_string_argv);
     }
 

--- a/Proxy/config.h
+++ b/Proxy/config.h
@@ -16,6 +16,7 @@ struct {
     wchar_t *mono_corlib_dir;
     wchar_t *mono_dll_search_path_override;
     BOOL mono_debug_enabled;
+    BOOL mono_debug_suspend;
     wchar_t* mono_debug_address;
 } config;
 

--- a/Proxy/main.c
+++ b/Proxy/main.c
@@ -208,11 +208,19 @@ int init_doorstop_il2cpp(const char *domain_name) {
         size_t len_debugger_option = strlen(debugger_option);
         char* debug_address = narrow(config.mono_debug_address);
         size_t len_debug_address = strlen(debug_address);
+        const char* no_suspend = ",suspend=n";
+        size_t len_no_suspend = strlen(no_suspend);
 
         size_t len_option = len_debugger_option + len_debug_address;
+        if (!config.mono_debug_suspend) {
+            len_option += len_no_suspend;
+        }
         char* option = malloc((len_option + 1) * sizeof(char));
         memcpy(option, debugger_option, len_debugger_option);
         memcpy(option + len_debugger_option, debug_address, len_debug_address);
+        if (!config.mono_debug_suspend) {
+            memcpy(option + len_debugger_option + len_debug_address, no_suspend, len_no_suspend);
+        }
         option[len_option + 1] = '\0';
 
         const char* options[] = {

--- a/docs/dist_readme.md
+++ b/docs/dist_readme.md
@@ -117,6 +117,8 @@ configDir=
 corlibDir=
 # Specifies whether the mono soft debugger is enabled
 debugEnabled=false
+# Specifies whether the mono soft debugger should suspend the process and wait for the remote debugger
+debugSuspend=false
 # Specifies the listening address the soft debugger
 debugAddress=127.0.0.1:10000
 ```

--- a/docs/doorstop_config.ini
+++ b/docs/doorstop_config.ini
@@ -29,5 +29,7 @@ configDir=
 corlibDir=
 # Specifies whether the mono soft debugger is enabled
 debugEnabled=false
+# Specifies whether the mono soft debugger should suspend the process and wait for the remote debugger
+debugSuspend=false
 # Specifies the listening address the soft debugger
 debugAddress=127.0.0.1:10000


### PR DESCRIPTION
Now you can decide whether the game process should be suspended when mono gets initialized.
It only works for debugging.