### PR TITLE
Fix macos support. Fix run script.

### DIFF
--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -246,9 +246,18 @@ doorstop_directory="${BASEDIR}/"
 doorstop_name="libdoorstop.${lib_extension}"
 
 export LD_LIBRARY_PATH="${doorstop_directory}:${corlib_dir}:${LD_LIBRARY_PATH}"
-export LD_PRELOAD="${doorstop_name}:${LD_PRELOAD}"
-export DYLD_LIBRARY_PATH="${doorstop_directory}:${corlib_dir}:${DYLD_LIBRARY_PATH}"
-export DYLD_INSERT_LIBRARIES="${doorstop_name}:${DYLD_INSERT_LIBRARIES}"
+if [ -z "$LD_PRELOAD" ]; then
+    export LD_PRELOAD="${doorstop_name}"
+else
+    export LD_PRELOAD="${doorstop_name}:${LD_PRELOAD}"
+fi
+
+export DYLD_LIBRARY_PATH="${doorstop_directory}:${DYLD_LIBRARY_PATH}"
+if [ -z "$DYLD_INSERT_LIBRARIES" ]; then
+    export DYLD_INSERT_LIBRARIES="${doorstop_name}"
+else
+    export DYLD_INSERT_LIBRARIES="${doorstop_name}:${DYLD_INSERT_LIBRARIES}"
+fi
 
 # shellcheck disable=SC2086
 exec "$executable_path" $rest_args

--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -74,7 +74,6 @@ __attribute__((constructor)) void doorstop_ctor() {
 
     void *unity_player = plthook_handle_by_name("UnityPlayer");
 
-    // TODO: Chekc if this still works on macOS
     if (unity_player && plthook_open_by_handle(&hook, unity_player) == 0) {
         LOG("Found UnityPlayer, hooking into it instead");
     } else if (plthook_open(&hook, NULL) != 0) {

--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -75,7 +75,7 @@ __attribute__((constructor)) void doorstop_ctor() {
     void *unity_player = plthook_handle_by_name("UnityPlayer");
 
     // TODO: Chekc if this still works on macOS
-    if (unity_player && plthook_open_by_address(&hook, unity_player) == 0) {
+    if (unity_player && plthook_open_by_handle(&hook, unity_player) == 0) {
         LOG("Found UnityPlayer, hooking into it instead");
     } else if (plthook_open(&hook, NULL) != 0) {
         LOG("Failed to open current process PLT! Cannot run Doorstop! "


### PR DESCRIPTION
- Fix an extra colon when the `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES` is empty #25 
- Fix macos and linux support #26 