### PR TITLE
Use string_chars instead of string_to_utf8 in UNICODE mode

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -114,8 +114,13 @@ void mono_doorstop_bootstrap(void *mono_domain) {
         LOG("Error invoking code!");
         if (mono.object_to_string) {
             void *str = mono.object_to_string(exc, NULL);
+#ifdef UNICODE
+            char_t *exc_str = mono.string_chars(str);
+            LOG("Error message: %s", exc_str);
+#else
             char *exc_str = mono.string_to_utf8(str);
             LOG("Error message: %s", exc_str);
+#endif
         }
     }
     LOG("Done");

--- a/src/runtimes/mono.h
+++ b/src/runtimes/mono.h
@@ -27,6 +27,9 @@ DEF_CALL(void, config_parse, const char *filename)
 DEF_CALL(void, set_assemblies_path, const char *path)
 DEF_CALL(void *, object_to_string, void *obj, void **exc)
 DEF_CALL(char *, string_to_utf8, void *s)
+#ifdef UNICODE
+DEF_CALL(char_t *, string_chars, void *mono_string)
+#endif
 DEF_CALL(void *, image_open_from_data_with_name, void *data,
          unsigned long data_len, int need_copy, MonoImageOpenStatus *status,
          int refonly, const char *name)


### PR DESCRIPTION
The original code was taking a MonoString and then calling string_to_utf8 on it. That result was passed to LOG, which called narrow on the result, which was mangling our string.

Before:
Error invoking code!
Error message: 祓瑳浥吮灹䱥慯䕤捸灥楴湯›潃汵⁤潮⁴潬摡琠灹⁥景映敩摬✠協獅楰湯条⹥獅楰湯条䍥湯楦㩧楨敤汐祡牥 ...

After:
Error invoking code!
Error message: System.TypeLoadException: Could not load type of field 'TSEspionage.EspionageConfig:hidePlayers' (1) due to: Could not load file or assembly 'System.Collections, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. assembly:System.Collections, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a type:<unknown type> member:(null) signature:<none>
  at Doorstop.Entrypoint.Start () [0x00001] in ...