### PR TITLE
Fixed broken path for output_log

### DIFF
--- a/src/windows/entrypoint.c
+++ b/src/windows/entrypoint.c
@@ -104,7 +104,7 @@ void redirect_output_log(DoorstopPaths const *paths) {
         return;
 
     char_t *cmd = GetCommandLine();
-    size_t app_dir_len = strlen(paths->doorstop_filename);
+    size_t app_dir_len = strlen(paths->app_dir);
     size_t cmd_len = strlen(cmd);
     size_t new_cmd_len = cmd_len + LOG_FILE_CMD_START_LEN + app_dir_len +
                          LOG_FILE_CMD_END_LEN + LOG_FILE_CMD_EXTRA;


### PR DESCRIPTION
Being given the option for Doorstop to automatically redirect the output log is neat, and it saves me from running additional code to patch `mainData` for the redirect.

However, the path used for it is clearly incorrect, and I've noticed that it isn't just an issue for me: #39 

After having a quick peek it appears that the wrong path variable is being used for the absolute directory path, resulting in it being trimmed early due to the filename length being short.
```c
size_t app_dir_len = strlen(paths->doorstop_filename); // A simple goof!
```

A quick change resolves this issue:
```c
size_t app_dir_len = strlen(paths->app_dir); // Yay it works!
```