### PR TITLE
Change how the mono search path is configured and change its default logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,11 +74,3 @@ The change was made for two reasons:
 
 * Doorstop does not need to pass any arguments anymore. Instead, Doorstop passes all the information via environment variables.
 * CoreCLR does not support easy method searching using wildcards yet.
-
-## *Possibly* breaking: `target_assembly` directory is now always added to mono search path
-
-In UnityDoorstop 3.x, the tool only loaded the `target_assembly` and left any other assembly resolving to the target assembly code.
-**Starting Doorstop 4, `target_assembly`'s parent directory is set to mono DLL search path.**
-
-This means that any additional assemblies that are placed into the same directory as `target_assembly` will receive priority during assembly resolving.
-Note that this option for now only affects UnityMono as there is no similar search path priority available via current CoreCLR C hosting API.

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -36,6 +36,7 @@ ignore_disable_switch="0"
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
+# To specify multiple paths, separate them with colons (:)
 dll_search_path_override=""
 
 # If 1, Mono debugger server will be enabled

--- a/assets/windows/doorstop_config.ini
+++ b/assets/windows/doorstop_config.ini
@@ -24,6 +24,7 @@ ignore_disable_switch=false
 # (e.g. mscorlib is stripped in original game)
 # This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
 # Original Managed folder is added as a secondary folder in the search path
+# To specify multiple paths, separate them with semicolons (;)
 dll_search_path_override=
 
 # If true, Mono debugger server will be enabled

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -134,10 +134,6 @@ void *init_mono(const char *root_domain_name, const char *runtime_version) {
     LOG("Overriding mono DLL search path");
 
     size_t mono_search_path_len = strlen(root_dir) + 1;
-    char_t *target_path_full = get_full_path(config.target_assembly);
-    char_t *target_path_folder = get_folder_name(target_path_full);
-    mono_search_path_len += strlen(target_path_folder) + 1;
-    LOG("Adding %s to mono search path", target_path_folder);
 
     char_t *override_dir_full = NULL;
     bool_t has_override = config.mono_dll_search_path_override &&
@@ -153,8 +149,6 @@ void *init_mono(const char *root_domain_name, const char *runtime_version) {
         strcat(mono_search_path, override_dir_full);
         strcat(mono_search_path, PATH_SEP);
     }
-    strcat(mono_search_path, target_path_folder);
-    strcat(mono_search_path, PATH_SEP);
     strcat(mono_search_path, root_dir);
 
     LOG("Mono search path: %s", mono_search_path);
@@ -166,8 +160,6 @@ void *init_mono(const char *root_domain_name, const char *runtime_version) {
     if (override_dir_full) {
         free(override_dir_full);
     }
-    free(target_path_full);
-    free(target_path_folder);
 
     hook_mono_jit_parse_options(0, NULL);
 

--- a/src/nix/config.c
+++ b/src/nix/config.c
@@ -37,8 +37,8 @@ void load_config() {
     try_get_env("DOORSTOP_MONO_DEBUG_ADDRESS", TEXT("127.0.0.1:10000"),
                 &config.mono_debug_address);
     get_env_path("DOORSTOP_TARGET_ASSEMBLY", &config.target_assembly);
-    get_env_path("DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE",
-                 &config.mono_dll_search_path_override);
+    try_get_env("DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE", TEXT(""),
+                &config.mono_dll_search_path_override);
     get_env_path("DOORSTOP_CLR_RUNTIME_CORECLR_PATH",
                  &config.clr_runtime_coreclr_path);
     get_env_path("DOORSTOP_CLR_CORLIB_DIR", &config.clr_corlib_dir);

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -72,9 +72,9 @@ static inline void init_config_file() {
     load_path_file(config_path, TEXT("General"), TEXT("target_assembly"),
                    DEFAULT_TARGET_ASSEMBLY, &config.target_assembly);
 
-    load_path_file(config_path, TEXT("UnityMono"),
-                   TEXT("dll_search_path_override"), NULL,
-                   &config.mono_dll_search_path_override);
+    load_str_file(config_path, TEXT("UnityMono"),
+                  TEXT("dll_search_path_override"), TEXT(""),
+                  &config.mono_dll_search_path_override);
     load_bool_file(config_path, TEXT("UnityMono"), TEXT("debug_enabled"),
                    TEXT("false"), &config.mono_debug_enabled);
     load_bool_file(config_path, TEXT("UnityMono"), TEXT("debug_suspend"),


### PR DESCRIPTION
This pr does 2 changes:
- Revert the breaking change where the target assembly's parent directory was always added to the mono search path, it no longer does it with this pr
- To compensate for the above, add the ability for the search path override settings to support for more than 1 path. The paths must be split by the same OS dependant separator that mono uses

This is followed by a regression that came up in BepInEx where an assembly hook load couldn't work due the assembly of interest being preloaded due to the search path's default. This pr brings back the flexibility of allowing the target assembly to hook on loading assemblies located on the same folder.

However, if it was just a revert, it would now become annoying to opt into it because the mono override path setting only supported a single path to add. For this reason, I implemented support to have multiple paths in that setting.

The path splitting part isn't a breaking change: the format is backwards compatible if no separator was defined and it's not possible a separator existed in the path because mono was always splitting on the same separators internally. Effectively, it makes it non breaking on any path that can work, it just adds the feature.

The default behavior change however CAN be breaking if there was the expectation that this was the default. However, it's not something that can't be fixed thanks to the multiple search paths support so it's something that can be mentioned in the release note just in case.

I tested this using bepinex v5 on Windows and Linux with a couple of different cases. I made the parsing resilient against leading, trailing or duplicate separators.