### PR TITLE
Widen the error message string when invoking the entrypoint

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -114,8 +114,12 @@ void mono_doorstop_bootstrap(void *mono_domain) {
         LOG("Error invoking code!");
         if (mono.object_to_string) {
             void *str = mono.object_to_string(exc, NULL);
-            char *exc_str = mono.string_to_utf8(str);
+            char *exc_str_n = mono.string_to_utf8(str);
+            char_t *exc_str = widen(exc_str_n);
             LOG("Error message: %s", exc_str);
+            LOG("\n");
+            free(exc_str);
+            mono.free(exc_str_n);
         }
     }
     LOG("Done");

--- a/src/runtimes/mono.h
+++ b/src/runtimes/mono.h
@@ -27,6 +27,7 @@ DEF_CALL(void, config_parse, const char *filename)
 DEF_CALL(void, set_assemblies_path, const char *path)
 DEF_CALL(void *, object_to_string, void *obj, void **exc)
 DEF_CALL(char *, string_to_utf8, void *s)
+DEF_CALL(void, free, void *ptr)
 DEF_CALL(void *, image_open_from_data_with_name, void *data,
          unsigned long data_len, int need_copy, MonoImageOpenStatus *status,
          int refonly, const char *name)


### PR DESCRIPTION
Supercedes #30 

I did what @ghorsington suggested and I found I could easily repro the issue as well as confirming that their suggestions fixed it (to repro, simply have the entrypoint throw on Windows).