### PR TITLE
Add the ability to override the Unity's boot.config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ All Doorstop arguments start with `--doorstop-` and always contain an argument. 
 * `string` = any sequence of characters and numbers. Wrap into `"`s if the string contains spaces
 
 | Argument                                          | Description                                                                                          |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| ------------------------------------------------- |------------------------------------------------------------------------------------------------------|
 | `--doorstop-enabled bool`                         | Enable or disable Doorstop.                                                                          |
 | `--doorstop-redirect-output-log bool`             | *Only on Windows*: If `true` Unity's output log is redirected to `<current folder>\output_log.txt`   |
 | `--doorstop-target-assembly string`               | Path to the assembly to load and execute.                                                            |
+| `--doorstop-boot-config-override string`          | Overrides the boot.config file path.                                                                 |
 | `--doorstop-mono-dll-search-path-override string` | Overrides default Mono DLL search path                                                               |
 | `--doorstop-mono-debug-enabled bool`              | If true, Mono debugger server will be enabled                                                        |
 | `--doorstop-mono-debug-suspend bool`              | Whether to suspend the game execution until the debugger is attached.                                |

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -25,6 +25,9 @@ enabled="1"
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly="Doorstop.dll"
 
+# Overrides the default boot.config file path
+boot_config_override=
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch="0"
@@ -197,6 +200,10 @@ while :; do
             target_assembly="$2"
             shift
         ;;
+        --doorstop-boot-config-override)
+            boot_config_override="$2"
+            shift
+        ;;
         --doorstop-mono-dll-search-path-override)
             dll_search_path_override="$2"
             shift
@@ -234,6 +241,7 @@ done
 # Move variables to environment
 export DOORSTOP_ENABLED="$enabled"
 export DOORSTOP_TARGET_ASSEMBLY="$target_assembly"
+export DOORSTOP_BOOT_CONFIG_OVERRIDE="$boot_config_override"
 export DOORSTOP_IGNORE_DISABLED_ENV="$ignore_disable_switch"
 export DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE="$dll_search_path_override"
 export DOORSTOP_MONO_DEBUG_ENABLED="$debug_enable"

--- a/assets/windows/doorstop_config.ini
+++ b/assets/windows/doorstop_config.ini
@@ -11,6 +11,9 @@ target_assembly=Doorstop.dll
 # If true, Unity's output log is redirected to <current folder>\output_log.txt
 redirect_output_log=false
 
+# Overrides the default boot.config file path
+boot_config_override=
+
 # If enabled, DOORSTOP_DISABLE env var value is ignored
 # USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
 ignore_disable_switch=false

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -267,14 +267,14 @@ void il2cpp_doorstop_bootstrap() {
     strcat(app_paths_env, config.clr_corlib_dir);
     strcat(app_paths_env, PATH_SEP);
     strcat(app_paths_env, target_dir);
-    char *app_paths_env_n = narrow(app_paths_env);
+    const char *app_paths_env_n = narrow(app_paths_env);
 
     LOG("App path: %s", app_path);
     LOG("Target dir: %s", target_dir);
     LOG("Target name: %s", target_name);
     LOG("APP_PATHS: %s", app_paths_env);
 
-    char *props = "APP_PATHS";
+    const char *props = "APP_PATHS";
 
     setenv(TEXT("DOORSTOP_INITIALIZED"), TEXT("TRUE"), TRUE);
     setenv(TEXT("DOORSTOP_INVOKE_DLL_PATH"), config.target_assembly, TRUE);
@@ -293,7 +293,8 @@ void il2cpp_doorstop_bootstrap() {
 
     void (*startup)() = NULL;
     result = coreclr.create_delegate(host, domain_id, target_name_n,
-                                     "Doorstop.Entrypoint", "Start", &startup);
+                                     "Doorstop.Entrypoint", "Start",
+                                     (void **)&startup);
     if (result != 0) {
         LOG("Failed to get entrypoint delegate: 0x%08x", result);
         return;

--- a/src/config/common.c
+++ b/src/config/common.c
@@ -11,6 +11,7 @@ void cleanup_config() {
     }
 
     FREE_NON_NULL(config.target_assembly);
+    FREE_NON_NULL(config.boot_config_override);
     FREE_NON_NULL(config.mono_dll_search_path_override);
     FREE_NON_NULL(config.clr_corlib_dir);
     FREE_NON_NULL(config.clr_runtime_coreclr_path);
@@ -27,6 +28,7 @@ void init_config_defaults() {
     config.mono_debug_suspend = FALSE;
     config.mono_debug_address = NULL;
     config.target_assembly = NULL;
+    config.boot_config_override = NULL;
     config.mono_dll_search_path_override = NULL;
     config.clr_corlib_dir = NULL;
     config.clr_runtime_coreclr_path = NULL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -36,6 +36,12 @@ typedef struct {
     char_t *target_assembly;
 
     /**
+     * @brief Path to a custom boot.config file to use. If enabled, this file
+     * takes precedence over the default one in the Data folder.
+     */
+    char_t *boot_config_override;
+
+    /**
      * @brief Path to use as the main DLL search path. If enabled, this folder
      * takes precedence over the default Managed folder.
      */

--- a/src/nix/config.c
+++ b/src/nix/config.c
@@ -10,7 +10,7 @@ void get_env_bool(const char_t *name, bool_t *target) {
     }
 }
 
-void try_get_env(const char_t *name, const char_t *def, char_t **target) {
+void try_get_env(const char_t *name, char_t *def, char_t **target) {
     char_t *value = getenv(name);
     if (value != NULL && strlen(value) > 0) {
         *target = strdup(value);

--- a/src/nix/config.c
+++ b/src/nix/config.c
@@ -37,6 +37,7 @@ void load_config() {
     try_get_env("DOORSTOP_MONO_DEBUG_ADDRESS", TEXT("127.0.0.1:10000"),
                 &config.mono_debug_address);
     get_env_path("DOORSTOP_TARGET_ASSEMBLY", &config.target_assembly);
+    get_env_path("DOORSTOP_BOOT_CONFIG_OVERRIDE", &config.boot_config_override);
     try_get_env("DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE", TEXT(""),
                 &config.mono_dll_search_path_override);
     get_env_path("DOORSTOP_CLR_RUNTIME_CORECLR_PATH",

--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -59,6 +59,29 @@ int fclose_hook(FILE *stream) {
     return fclose(stream);
 }
 
+char_t *default_boot_config_path = NULL;
+FILE *fopen64_hook(char *filename, char *mode) {
+    char *actual_file_name = filename;
+
+    if (strcmp(filename, default_boot_config_path) == 0) {
+        actual_file_name = config.boot_config_override;
+        LOG("Overriding boot.config to %s", actual_file_name);
+    }
+
+    return fopen64(actual_file_name, mode);
+}
+
+FILE *fopen_hook(char *filename, char *mode) {
+    char *actual_file_name = filename;
+
+    if (strcmp(filename, default_boot_config_path) == 0) {
+        actual_file_name = config.boot_config_override;
+        LOG("Overriding boot.config to %s", actual_file_name);
+    }
+
+    return fopen(actual_file_name, mode);
+}
+
 int dup2_hook(int od, int nd) {
     // Newer versions of Unity redirect stdout to player.log, we don't want
     // that
@@ -80,7 +103,8 @@ __attribute__((constructor)) void doorstop_ctor() {
 
     void *unity_player = plthook_handle_by_name("UnityPlayer");
 
-    if (unity_player && PLTHOOK_OPEN_BY_HANDLE_OR_ADDRESS(&hook, unity_player) == 0) {
+    if (unity_player &&
+        PLTHOOK_OPEN_BY_HANDLE_OR_ADDRESS(&hook, unity_player) == 0) {
         LOG("Found UnityPlayer, hooking into it instead");
     } else if (plthook_open(&hook, NULL) != 0) {
         LOG("Failed to open current process PLT! Cannot run Doorstop! "
@@ -93,6 +117,29 @@ __attribute__((constructor)) void doorstop_ctor() {
     if (plthook_replace(hook, "dlsym", &dlsym_hook, NULL) != 0)
         printf("Failed to hook dlsym, ignoring it. Error: %s\n",
                plthook_error());
+
+    if (config.boot_config_override) {
+        if (file_exists(config.boot_config_override)) {
+            default_boot_config_path = calloc(MAX_PATH, sizeof(char_t));
+            memset(default_boot_config_path, 0, MAX_PATH * sizeof(char_t));
+            strcat(default_boot_config_path, get_working_dir());
+            strcat(default_boot_config_path, TEXT("/"));
+            strcat(default_boot_config_path,
+                   get_file_name(program_path(), FALSE));
+            strcat(default_boot_config_path, TEXT("_Data/boot.config"));
+
+            if (plthook_replace(hook, "fopen64", &fopen64_hook, NULL) != 0)
+                printf("Failed to hook fopen64, ignoring it. Error: %s\n",
+                       plthook_error());
+            if (plthook_replace(hook, "fopen", &fopen_hook, NULL) != 0)
+                printf("Failed to hook fopen, ignoring it. Error: %s\n",
+                       plthook_error());
+        } else {
+            LOG("The boot.config file won't be overriden because the provided "
+                "one does not exist: %s",
+                config.boot_config_override);
+        }
+    }
 
     if (plthook_replace(hook, "fclose", &fclose_hook, NULL) != 0)
         printf("Failed to hook fclose, ignoring it. Error: %s\n",

--- a/src/nix/entrypoint.c
+++ b/src/nix/entrypoint.c
@@ -60,6 +60,7 @@ int fclose_hook(FILE *stream) {
 }
 
 char_t *default_boot_config_path = NULL;
+#if !defined(__APPLE__)
 FILE *fopen64_hook(char *filename, char *mode) {
     char *actual_file_name = filename;
 
@@ -70,6 +71,7 @@ FILE *fopen64_hook(char *filename, char *mode) {
 
     return fopen64(actual_file_name, mode);
 }
+#endif
 
 FILE *fopen_hook(char *filename, char *mode) {
     char *actual_file_name = filename;
@@ -128,9 +130,11 @@ __attribute__((constructor)) void doorstop_ctor() {
                    get_file_name(program_path(), FALSE));
             strcat(default_boot_config_path, TEXT("_Data/boot.config"));
 
+#if !defined(__APPLE__)
             if (plthook_replace(hook, "fopen64", &fopen64_hook, NULL) != 0)
                 printf("Failed to hook fopen64, ignoring it. Error: %s\n",
                        plthook_error());
+#endif
             if (plthook_replace(hook, "fopen", &fopen_hook, NULL) != 0)
                 printf("Failed to hook fopen, ignoring it. Error: %s\n",
                        plthook_error());

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -24,7 +24,9 @@ typedef int bool_t;
 
 #define TRUE 1
 #define FALSE 0
+#ifndef NULL
 #define NULL 0
+#endif
 
 #define TEXT(text) text
 

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -72,7 +72,7 @@ static inline void init_config_file() {
     load_path_file(config_path, TEXT("General"), TEXT("target_assembly"),
                    DEFAULT_TARGET_ASSEMBLY, &config.target_assembly);
     load_path_file(config_path, TEXT("General"), TEXT("boot_config_override"),
-                   TEXT(""), &config.boot_config_override);
+                   NULL, &config.boot_config_override);
 
     load_str_file(config_path, TEXT("UnityMono"),
                   TEXT("dll_search_path_override"), TEXT(""),

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -71,6 +71,8 @@ static inline void init_config_file() {
                    TEXT("false"), &config.redirect_output_log);
     load_path_file(config_path, TEXT("General"), TEXT("target_assembly"),
                    DEFAULT_TARGET_ASSEMBLY, &config.target_assembly);
+    load_path_file(config_path, TEXT("General"), TEXT("boot_config_override"),
+                   TEXT(""), &config.boot_config_override);
 
     load_str_file(config_path, TEXT("UnityMono"),
                   TEXT("dll_search_path_override"), TEXT(""),
@@ -144,6 +146,8 @@ static inline void init_cmd_args() {
                   config.redirect_output_log, load_bool_argv);
         PARSE_ARG(TEXT("--doorstop-target-assembly"), config.target_assembly,
                   load_path_argv);
+        PARSE_ARG(TEXT("--doorstop-boot-config-override"),
+                  config.boot_config_override, load_path_argv);
 
         PARSE_ARG(TEXT("--doorstop-mono-dll-search-path-override"),
                   config.mono_dll_search_path_override, load_path_argv);

--- a/src/windows/entrypoint.c
+++ b/src/windows/entrypoint.c
@@ -223,7 +223,7 @@ void inject(DoorstopPaths const *paths) {
             strcat(default_boot_config_path, TEXT("_Data\\boot.config"));
 
             HOOK_SYS(target_module, CreateFileW, create_file_hook);
-            HOOK_SYS(target_module, CreateFileW, create_file_hook_narrow);
+            HOOK_SYS(target_module, CreateFileA, create_file_hook_narrow);
         } else {
             LOG("The boot.config file won't be overriden because the provided "
                 "one does not exist: %s",

--- a/src/windows/entrypoint.c
+++ b/src/windows/entrypoint.c
@@ -41,6 +41,8 @@ bool_t fix_cwd() {
 #define LOG_FILE_CMD_END L"\\output_log.txt\""
 #define LOG_FILE_CMD_END_LEN STR_LEN(LOG_FILE_CMD_END)
 
+char_t *default_boot_config_path = NULL;
+
 char_t *new_cmdline_args = NULL;
 char *new_cmdline_args_narrow = NULL;
 
@@ -61,6 +63,70 @@ bool_t WINAPI close_handle_hook(void *handle) {
     if (stdout_handle && handle == stdout_handle)
         return TRUE;
     return CloseHandle(handle);
+}
+
+HANDLE WINAPI create_file_hook(LPCWSTR lpFileName, DWORD dwDesiredAccess,
+                               DWORD dwShareMode,
+                               LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+                               DWORD dwCreationDisposition,
+                               DWORD dwFlagsAndAttributes,
+                               HANDLE hTemplateFile) {
+    LPCWSTR actual_file_name = lpFileName;
+
+    char_t *normalised_path = calloc(strlen(lpFileName) + 1, sizeof(char_t));
+    memset(normalised_path, 0, (strlen(lpFileName) + 1) * sizeof(char_t));
+    strcpy(normalised_path, lpFileName);
+    for (size_t i = 0; i < strlen(normalised_path); i++) {
+        if (normalised_path[i] == L'/') {
+            normalised_path[i] = L'\\';
+        }
+    }
+
+    if (strcmpi(normalised_path, default_boot_config_path) == 0) {
+        actual_file_name = config.boot_config_override;
+        LOG("Overriding boot.config to %s", actual_file_name);
+    }
+
+    free(normalised_path);
+
+    return CreateFileW(actual_file_name, dwDesiredAccess, dwShareMode,
+                       lpSecurityAttributes, dwCreationDisposition,
+                       dwFlagsAndAttributes, hTemplateFile);
+}
+
+HANDLE WINAPI create_file_hook_narrow(
+    void *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition,
+    DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
+    void *actual_file_name = lpFileName;
+
+    char_t *widened_filename = widen(lpFileName);
+    char_t *normalised_path =
+        calloc(strlen(widened_filename) + 1, sizeof(char_t));
+    memset(normalised_path, 0, (strlen(widened_filename) + 1) * sizeof(char_t));
+    strcpy(normalised_path, widened_filename);
+    free(widened_filename);
+
+    for (size_t i = 0; i < strlen(normalised_path); i++) {
+        if (normalised_path[i] == L'/') {
+            normalised_path[i] = L'\\';
+        }
+    }
+
+    if (strcmpi(normalised_path, default_boot_config_path) == 0) {
+        char *narrowed_boot_config_override =
+            narrow(config.boot_config_override);
+        memcpy(actual_file_name, narrowed_boot_config_override,
+               strlen(config.boot_config_override));
+        free(narrowed_boot_config_override);
+        LOG("Overriding boot.config to %s", actual_file_name);
+    }
+
+    free(normalised_path);
+
+    return CreateFileA(actual_file_name, dwDesiredAccess, dwShareMode,
+                       lpSecurityAttributes, dwCreationDisposition,
+                       dwFlagsAndAttributes, hTemplateFile);
 }
 
 void capture_mono_path(void *handle) {
@@ -146,6 +212,25 @@ void inject(DoorstopPaths const *paths) {
 
     HOOK_SYS(target_module, GetProcAddress, get_proc_address_detour);
     HOOK_SYS(target_module, CloseHandle, close_handle_hook);
+    if (config.boot_config_override) {
+        if (file_exists(config.boot_config_override)) {
+            default_boot_config_path = calloc(MAX_PATH, sizeof(char_t));
+            memset(default_boot_config_path, 0, MAX_PATH * sizeof(char_t));
+            strcat(default_boot_config_path, get_working_dir());
+            strcat(default_boot_config_path, TEXT("\\"));
+            strcat(default_boot_config_path,
+                   get_file_name(program_path(), FALSE));
+            strcat(default_boot_config_path, TEXT("_Data\\boot.config"));
+
+            HOOK_SYS(target_module, CreateFileW, create_file_hook);
+            HOOK_SYS(target_module, CreateFileW, create_file_hook_narrow);
+        } else {
+            LOG("The boot.config file won't be overriden because the provided "
+                "one does not exist: %s",
+                config.boot_config_override);
+        }
+    }
+
     HOOK_SYS(app_module, GetCommandLineW, get_command_line_hook);
     HOOK_SYS(app_module, GetCommandLineA, get_command_line_hook_narrow);
 


### PR DESCRIPTION
This covers some niche usecases I thought fit within doorstop, but it takes a bit of an explanation of what I wanted to do that lead me to add this feature.

Unity games have a file in their data folder called "boot.config" which is a simple key value pair file (kinda like a .ini, but without sections or comments) that configures various boot parameters. While this file is not documented, some simple reversing with ghidra revealed there's actually nothing that tells what is a valid key: it's just agreed upon by the file and uinity's player. It means the valid keys depends on the version and the player.

What I wanted to do was to have a unity 2018.4 game use the newer mono runtime this version supported. It's normally the default one, but for the specific game I was dealing with, it wasn't for historical reasons. Upgrading the runtime is already possible with doorstop: copy the MonoBleedingEdge folder from unity to the game, copy the corlibs and tell doorstop to look for them where you placed them. Easy....

...except there's one step left: in order for unity's player to even ATTEMPT to use MonoBleedingEdge instead of Mono, you HAVE to change the boot.config file in the data folder so it says:
```
scripting-runtime-version=latest
```
Instead of
```
scripting-runtime-version=legacy
```
There is no way around this one: I even checked with ghidra and it absolutely needs to be changed for this upgrade to work. The problem with this is doing this requires modifying a game's file which is intrusive for multiple reasons (the main one I can think of is this won't survive a Steam's survive integrity).

So I wanted to have a way to set this up without changing the original boot.config. This lead me to realise this file is loaded EXTREMELY early, WAY earlier than even mono. It means the only way I can do something is with doorstop by hooking into the player's call to loading the file.

And this is what leads me to this pr: I added hooks (tested on Windoes and Linux) that adds a config option where you can specify a custom path to an external boot.config. It hooks into CreateFileW/A and fopen/fopen64 to track when it tries to open the file and when it detects it, it will change the filename to call it with effectively redirecting the file path.

Since the exact options you can do varies per versions/players and I only needed this to change one key's value, it's unclear what are all the possibilities you can do with this, but my thinking is if I needed to mess with this for something like that, I could see this feature being useful here.

I also think it should be possible with a publicised set of unity's dll to actually read or set these values from the managed side (my ghidra reversing suggests they left bindings in an internal class which could be exposed after publicisation).