### PR TITLE
Platform detection on MinGW+Windows

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -51,7 +51,7 @@ target("doorstop")
 
         if is_arch("i386") then
             add_shflags("-e _DllEntry", "-Wl,--enable-stdcall-fixup", {force=true})
-        elseif is_arch("x86_64") then
+        elseif is_arch("x64", "x86_64") then
             add_shflags("-e DllEntry", {force=true})
         end
     end


### PR DESCRIPTION
In the xmake config script, there is a platform check performed when the build system is MinGW.
https://github.com/NeighTools/UnityDoorstop/blob/5607be4656a6fee6a811179343b9094e1b6d5639/xmake.lua#L49-L57
When running on my Windows machine under MinGW, neither branch is being taken and the library produced has no valid entrypoint.

Here's what `xmake show` tells on my machine:
```
> tools\xmake\xmake show
The information of xmake:
    version: 2.6.1+HEAD.666dc5479
    host: windows/x64
    programdir: E:\Coding\UnityDoorstop\tools\xmake
    programfile: E:\Coding\UnityDoorstop\tools\xmake\xmake.exe
    globaldir: C:\Users\%username%\AppData\Local\.xmake
    tmpdir: C:\Users\%username%\AppData\Local\Temp\.xmake\240817
    workingdir: E:\Coding\UnityDoorstop
    packagedir: C:\Users\%username%\AppData\Local\.xmake\packages
    packagedir(cache): C:\Users\%username%\AppData\Local\.xmake\cache\packages\2408

The information of project:
    plat: mingw
    arch: x64
    mode: release
    buildir: build
    configdir: E:\Coding\UnityDoorstop\.xmake\windows\x64
    projectdir: E:\Coding\UnityDoorstop
    projectfile: E:\Coding\UnityDoorstop\xmake.lua
```

The supplied fix fix for that changes the condition on line 54 to `is_arch("x64", "x86_64")`, as also suggested by [xmake docs](https://xmake.io/mirror/manual/target_instance.html#targetis_arch).