### PR TITLE
Upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/build-be.yml
+++ b/.github/workflows/build-be.yml
@@ -34,12 +34,12 @@ jobs:
           Copy-Item -Path ./assets/windows/doorstop_config.ini -Destination ./artifacts/verbose/x64/doorstop_config.ini
           Copy-Item -Path ./assets/windows/doorstop_config.ini -Destination ./artifacts/verbose/x86/doorstop_config.ini
       - name: Upload Release
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_win_release
           path: artifacts/release
       - name: Upload Verbose
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_win_verbose
           path: artifacts/verbose
@@ -83,17 +83,17 @@ jobs:
           cp assets/nix/run.sh artifacts/debug/x86/run.sh
           cp assets/nix/run.sh artifacts/debug/x64/run.sh
       - name: Upload Release
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_linux_release
           path: artifacts/release
       - name: Upload Verbose
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_linux_verbose
           path: artifacts/verbose
       - name: Upload Debug
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_linux_debug
           path: artifacts/debug
@@ -126,17 +126,17 @@ jobs:
           cp build/macosx/x86_64/debug/.doorstop_version artifacts/debug/x64/.doorstop_version
           cp assets/nix/run.sh artifacts/debug/x64/run.sh
       - name: Upload Release
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_macos_release
           path: artifacts/release
       - name: Upload Verbose
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_macos_verbose
           path: artifacts/verbose
       - name: Upload Debug
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doorstop_macos_debug
           path: artifacts/debug


### PR DESCRIPTION
Allows the CI to build properly as v2 is completely deprecated and no longer works