### PR TITLE
Fix many problems with run.sh

### DIFF
--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -1,14 +1,12 @@
 #!/bin/sh
 # Doorstop start script
-# 
+#
 # Run the script to start the game with Doorstop enabled
 #
 # There are two ways to use this script
 #
 # 1. Via CLI: Run ./run.sh <path to game> [doorstop arguments] [game arguments]
 # 2. Via config: edit the options below and run ./run.sh without any arguments
-
-# 0 is false, 1 is true
 
 # LINUX: name of Unity executable
 # MACOS: name of the .app directory
@@ -19,6 +17,7 @@ executable_name=""
 # General Config Options
 
 # Enable Doorstop?
+# 0 is false, 1 is true
 enabled="1"
 
 # Path to the assembly to load and execute
@@ -135,7 +134,7 @@ abs_path() {
 }
 
 _readlink() {
-    # relative links with readlink (without -f) do not preserve the path info 
+    # relative links with readlink (without -f) do not preserve the path info
     ab_path="$(abs_path "$1")"
     link="$(readlink "${ab_path}")"
     case $link in
@@ -145,11 +144,10 @@ _readlink() {
     echo "$link"
 }
 
-
 resolve_executable_path () {
     e_path="$(abs_path "$1")"
-    
-    while [ -L "${e_path}" ]; do 
+
+    while [ -L "${e_path}" ]; do
         e_path=$(_readlink "${e_path}");
     done
     echo "${e_path}"

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -189,60 +189,70 @@ doorstop_bool() {
 }
 
 # Read from command line
-while :; do
+i=0; max=$#
+while [ $i -lt $max ]; do
     case "$1" in
         --doorstop_enabled) # For backwards compatibility. Renamed to --doorstop-enabled
             enabled="$(doorstop_bool "$2")"
             shift
+            i=$((i+1))
         ;;
         --doorstop_target_assembly) # For backwards compatibility. Renamed to --doorstop-target-assembly
             target_assembly="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-enabled)
             enabled="$(doorstop_bool "$2")"
             shift
+            i=$((i+1))
         ;;
         --doorstop-target-assembly)
             target_assembly="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-boot-config-override)
             boot_config_override="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-mono-dll-search-path-override)
             dll_search_path_override="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-mono-debug-enabled)
             debug_enable="$(doorstop_bool "$2")"
             shift
+            i=$((i+1))
         ;;
         --doorstop-mono-debug-suspend)
             debug_suspend="$(doorstop_bool "$2")"
             shift
+            i=$((i+1))
         ;;
         --doorstop-mono-debug-address)
             debug_address="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-clr-runtime-coreclr-path)
             coreclr_path="$2"
             shift
+            i=$((i+1))
         ;;
         --doorstop-clr-corlib-dir)
             corlib_dir="$2"
             shift
+            i=$((i+1))
         ;;
         *)
-            if [ -z "$1" ]; then
-                break
-            fi
-            rest_args="$rest_args $1"
+            set -- "$@" "$1"
         ;;
     esac
     shift
+    i=$((i+1))
 done
 
 # Move variables to environment
@@ -275,5 +285,4 @@ else
     export DYLD_INSERT_LIBRARIES="${doorstop_name}:${DYLD_INSERT_LIBRARIES}"
 fi
 
-# shellcheck disable=SC2086
-exec "$executable_path" $rest_args
+exec "$executable_path" "$@"

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -88,24 +88,23 @@ arch=""
 executable_path=""
 lib_extension=""
 
+abs_path() {
+    # Resolve relative path to absolute from BASEDIR
+    if [ "$1" = "${1#/}" ]; then
+        set -- "${BASEDIR}/${1}"
+    fi
+    echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
 # Set executable path and the extension to use for the libdoorstop shared object
 os_type="$(uname -s)"
 case ${os_type} in
     Linux*)
-        executable_path="${executable_name}"
-        # Handle relative paths
-        if [ "$executable_path" = "${executable_path#/}" ]; then
-            executable_path="${BASEDIR}/${executable_path}"
-        fi
+        executable_path="$(abs_path "$executable_name")"
         lib_extension="so"
     ;;
     Darwin*)
-        real_executable_name="${executable_name}"
-
-        # Handle relative directories
-        if [ "$real_executable_name" = "${real_executable_name#/}" ]; then
-            real_executable_name="${BASEDIR}/${real_executable_name}"
-        fi
+        real_executable_name="$(abs_path "$executable_name")"
 
         # If we're not even an actual executable, check .app Info for actual executable
         case $real_executable_name in
@@ -130,10 +129,6 @@ case ${os_type} in
         exit 1
     ;;
 esac
-
-abs_path() {
-    echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-}
 
 _readlink() {
     # relative links with readlink (without -f) do not preserve the path info
@@ -254,6 +249,8 @@ while [ $i -lt $max ]; do
     shift
     i=$((i+1))
 done
+
+target_assembly="$(abs_path "$target_assembly")"
 
 # Move variables to environment
 export DOORSTOP_ENABLED="$enabled"

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -92,6 +92,7 @@ for a in "$@"; do
                 rotated=$((rotated+1))
             fi
         done
+        echo 1>&2 "Please set executable_name to a valid name in a text editor"
         exit 1
     fi
 done
@@ -103,7 +104,7 @@ if [ -x "$1" ] ; then
 fi
 
 if [ -z "${executable_name}" ] || [ ! -x "${executable_name}" ]; then
-    echo "Please set executable_name to a valid name in a text editor or as the first command line parameter"
+    echo 1>&2 "Please set executable_name to a valid name in a text editor or as the first command line parameter"
     exit 1
 fi
 
@@ -150,8 +151,8 @@ case ${os_type} in
     ;;
     *)
         # alright whos running games on freebsd
-        echo "Unknown operating system ($(uname -s))"
-        echo "Make an issue at https://github.com/NeighTools/UnityDoorstop"
+        echo 1>&2 "Unknown operating system ($(uname -s))"
+        echo 1>&2 "Make an issue at https://github.com/NeighTools/UnityDoorstop"
         exit 1
     ;;
 esac
@@ -189,10 +190,10 @@ case "${file_out}" in
         arch="x86"
     ;;
     *)
-        echo "The executable \"${executable_path}\" is not compiled for x86 or x64 (might be ARM?)"
-        echo "If you think this is a mistake (or would like to encourage support for other architectures)"
-        echo "Please make an issue at https://github.com/NeighTools/UnityDoorstop"
-        echo "Got: ${file_out}"
+        echo 1>&2 "The executable \"${executable_path}\" is not compiled for x86 or x64 (might be ARM?)"
+        echo 1>&2 "If you think this is a mistake (or would like to encourage support for other architectures)"
+        echo 1>&2 "Please make an issue at https://github.com/NeighTools/UnityDoorstop"
+        echo 1>&2 "Got: ${file_out}"
         exit 1
     ;;
 esac

--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -92,7 +92,7 @@ for a in "$@"; do
                 rotated=$((rotated+1))
             fi
         done
-        echo 1>&2 "Please set executable_name to a valid name in a text editor"
+        echo "Please set executable_name to a valid name in a text editor" 1>&2
         exit 1
     fi
 done
@@ -104,7 +104,7 @@ if [ -x "$1" ] ; then
 fi
 
 if [ -z "${executable_name}" ] || [ ! -x "${executable_name}" ]; then
-    echo 1>&2 "Please set executable_name to a valid name in a text editor or as the first command line parameter"
+    echo "Please set executable_name to a valid name in a text editor or as the first command line parameter" 1>&2
     exit 1
 fi
 
@@ -151,8 +151,8 @@ case ${os_type} in
     ;;
     *)
         # alright whos running games on freebsd
-        echo 1>&2 "Unknown operating system ($(uname -s))"
-        echo 1>&2 "Make an issue at https://github.com/NeighTools/UnityDoorstop"
+        echo "Unknown operating system ($(uname -s))" 1>&2
+        echo "Make an issue at https://github.com/NeighTools/UnityDoorstop" 1>&2
         exit 1
     ;;
 esac
@@ -190,10 +190,10 @@ case "${file_out}" in
         arch="x86"
     ;;
     *)
-        echo 1>&2 "The executable \"${executable_path}\" is not compiled for x86 or x64 (might be ARM?)"
-        echo 1>&2 "If you think this is a mistake (or would like to encourage support for other architectures)"
-        echo 1>&2 "Please make an issue at https://github.com/NeighTools/UnityDoorstop"
-        echo 1>&2 "Got: ${file_out}"
+        echo "The executable \"${executable_path}\" is not compiled for x86 or x64 (might be ARM?)" 1>&2
+        echo "If you think this is a mistake (or would like to encourage support for other architectures)" 1>&2
+        echo "Please make an issue at https://github.com/NeighTools/UnityDoorstop" 1>&2
+        echo "Got: ${file_out}" 1>&2
         exit 1
     ;;
 esac


### PR DESCRIPTION
Don't output to stdout when not about to exit because of an error.
Make BASEDIR usable earlier such as in the config section.
Update the SteamLaunch check with a check that actually works currently and will hopefully be resilient to future changes in Steam.
Preserve spaces in passed arguments so it will not break on games installed to a path with spaces.