### PR TITLE
Run linux build in ubuntu:20.04 container

### DIFF
--- a/.github/workflows/build-be.yml
+++ b/.github/workflows/build-be.yml
@@ -48,15 +48,19 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+      env:
+        XMAKE_ROOT: y
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure paths
         run: |
-          mkdir -p artifacts/{verbose,release,debug}/{x86,x64}
+          bash -c "mkdir -p artifacts/{verbose,release,debug}/{x86,x64}"
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y git build-essential libreadline-dev ccache gcc-multilib g++-multilib
+        run: apt-get update && apt-get install -y git build-essential libreadline-dev ccache gcc-multilib g++-multilib clang curl
       - name: Build Release
         run: |
           ./build.sh


### PR DESCRIPTION
The Linux build commands will now run inside an ubuntu:20.04 container inside the ubuntu-latest GitHub Actions VM. The resulting libdoorstop.so's now have much relaxed GLIBC requirements of only 2.7 just like the UnityDoorstop.Unix version. There is an additional linking to libdl.so.2 but I don't believe that will cause any issues.

Fixes https://github.com/NeighTools/UnityDoorstop/issues/75