### PR TITLE
Add native plug‑in loading support

### DIFF
--- a/assets/nix/run.sh
+++ b/assets/nix/run.sh
@@ -24,6 +24,11 @@ enabled="1"
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly="Doorstop.dll"
 
+# Path to the unmanaged assembly to load and execute. its works like a ASI loader
+# It will try to call PluginMain, Start, or DllMain in that order if they exist
+# NOTE: This is optional, if not set, no native library will be loaded
+target_native_library=
+
 # Overrides the default boot.config file path
 boot_config_override=
 

--- a/assets/windows/doorstop_config.ini
+++ b/assets/windows/doorstop_config.ini
@@ -8,6 +8,11 @@ enabled=true
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
 target_assembly=Doorstop.dll
 
+# Path to the unmanaged assembly to load and execute. its works like a ASI loader
+# It will try to call PluginMain, Start, or DllMain in that order if they exist
+# NOTE: This is optional, if not set, no native library will be loaded
+target_native_library=
+
 # If true, Unity's output log is redirected to <current folder>\output_log.txt
 redirect_output_log=false
 

--- a/src/config/common.c
+++ b/src/config/common.c
@@ -11,6 +11,7 @@ void cleanup_config() {
     }
 
     FREE_NON_NULL(config.target_assembly);
+    FREE_NON_NULL(config.target_native_library);
     FREE_NON_NULL(config.boot_config_override);
     FREE_NON_NULL(config.mono_dll_search_path_override);
     FREE_NON_NULL(config.clr_corlib_dir);
@@ -28,6 +29,7 @@ void init_config_defaults() {
     config.mono_debug_suspend = FALSE;
     config.mono_debug_address = NULL;
     config.target_assembly = NULL;
+    config.target_native_library = NULL;
     config.boot_config_override = NULL;
     config.mono_dll_search_path_override = NULL;
     config.clr_corlib_dir = NULL;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -36,6 +36,11 @@ typedef struct {
     char_t *target_assembly;
 
     /**
+     * @brief Path to a unmanaged assembly to invoke.
+     */
+    char_t *target_native_library;
+
+    /**
      * @brief Path to a custom boot.config file to use. If enabled, this file
      * takes precedence over the default one in the Data folder.
      */

--- a/src/nix/config.c
+++ b/src/nix/config.c
@@ -37,6 +37,7 @@ void load_config() {
     get_env_bool("DOORSTOP_MONO_DEBUG_SUSPEND", &config.mono_debug_suspend);
     try_get_env("DOORSTOP_MONO_DEBUG_ADDRESS", TEXT("127.0.0.1:10000"),
                 &config.mono_debug_address);
+    get_env_path("DOORSTOP_TARGET_NATIVE_ASSEMBLY", &config.target_native_library);
     get_env_path("DOORSTOP_TARGET_ASSEMBLY", &config.target_assembly);
     get_env_path("DOORSTOP_BOOT_CONFIG_OVERRIDE", &config.boot_config_override);
     try_get_env("DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE", TEXT(""),
@@ -52,6 +53,7 @@ void load_config() {
     LOG("DOORSTOP_MONO_DEBUG_ENABLED: %d", config.mono_debug_enabled);
     LOG("DOORSTOP_MONO_DEBUG_SUSPEND: %d", config.mono_debug_suspend);
     LOG("DOORSTOP_MONO_DEBUG_ADDRESS: %s", config.mono_debug_address);
+    LOG("DOORSTOP_TARGET_NATIVE_ASSEMBLY: %s", config.target_native_library);
     LOG("DOORSTOP_TARGET_ASSEMBLY: %s", config.target_assembly);
     LOG("DOORSTOP_BOOT_CONFIG_OVERRIDE: %s", config.boot_config_override);
     LOG("DOORSTOP_MONO_DLL_SEARCH_PATH_OVERRIDE: %s",

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -69,6 +69,8 @@ static inline void init_config_file() {
                    TEXT("false"), &config.ignore_disabled_env);
     load_bool_file(config_path, TEXT("General"), TEXT("redirect_output_log"),
                    TEXT("false"), &config.redirect_output_log);
+    load_path_file(config_path, TEXT("General"), TEXT("target_native_library"),
+                   NULL, &config.target_native_library);
     load_path_file(config_path, TEXT("General"), TEXT("target_assembly"),
                    DEFAULT_TARGET_ASSEMBLY, &config.target_assembly);
     load_path_file(config_path, TEXT("General"), TEXT("boot_config_override"),

--- a/src/windows/entrypoint.c
+++ b/src/windows/entrypoint.c
@@ -284,6 +284,12 @@ BOOL WINAPI DllEntry(HINSTANCE hInstDll, DWORD reasonForDllLoad,
 
     redirect_output_log(paths);
 
+    if (!file_exists(config.target_native_library) &&
+        config.target_native_library != NULL) {
+        LOG("Could not find target native library!");
+        config.enabled = FALSE;
+    }
+
     if (!file_exists(config.target_assembly)) {
         LOG("Could not find target assembly!");
         config.enabled = FALSE;


### PR DESCRIPTION
This change introduces an optional `target_native_library` setting that allows Doorstop to load a C/C++ DLL in addition to the managed assembly.

I added this because UnityDoorstop has a conflict with regular ASI loaders for loading native plugins (for loading game cheats/hooks/...), and using both UnityDoorstop and ASI loader will most likely cause the game to crash (or it can make UnityDoorstop not work)

The bootstrap now calls `dlopen()/LoadLibrary()` on the configured DLL and invokes an exported entrypoint (falling back to `DllMain` on Windows if needed).

Configuration parsing on both Windows and *nix has been updated to support the new setting.